### PR TITLE
Wrapper that downloads stacking for a specific version and runs it

### DIFF
--- a/stacksmith
+++ b/stacksmith
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+stacksmith_cmd=stacksmith
+
+if [ "$1" == "--download-version" ]; then
+  version="$2"
+  
+  case "$version" in
+    v*)
+    tag="${version}"
+    ;;
+    *)
+    tag="v${version}"
+  esac
+  shift
+  shift
+  
+  echo "downloading ${version}"
+  
+  case "${OSTYPE}" in
+  darwin*)
+    suffix="-darwin-amd64"
+    ;;
+  win32)
+    suffix=".exe"
+    ;;
+  *)
+    suffix="-linux-amd64"
+    ;;
+  esac
+
+  stacksmith_cmd="$(mktemp)"
+  cleanup() {
+    rm -f "${stacksmith_cmd}"
+  }
+  trap cleanup EXIT INT TERM
+  
+  url="https://github.com/bitnami/stacksmith-cli/releases/download/${tag}/stacksmith${suffix}"
+  curl -Lf -o"${stacksmith_cmd}" "${url}"
+  chmod +x "${stacksmith_cmd}"
+
+fi
+
+
+"${stacksmith_cmd}" "$@"
+


### PR DESCRIPTION
simple script that can be installed in a CI agent, or embedded in a git repo and invoked to download and run the stacksmith binary. It offers an easy way to upgrade to the version you want to use, while also keeping you in control of when you want to upgrade (i.e. explicit version pinning)